### PR TITLE
Fix issue where indirect zone's pickDraw would act like a direct zone an...

### DIFF
--- a/src/vialab/SMT/SMTTouchManager.java
+++ b/src/vialab/SMT/SMTTouchManager.java
@@ -33,6 +33,8 @@ class SMTTouchManager {
 	 * them.
 	 */
 	public void handleTouches( ) {
+		SMT.sketch.drawIndirectChildren(true);
+
 		PGraphics temp = applet.g;
 		applet.g = picker.pg;
 		applet.g.beginDraw( );


### PR DESCRIPTION
...d so still be touchable outside of its parent.

This partially reverts commit 49755b, to get the behaviour back for pickDraw to support indirect zones.

Fixes https://github.com/vialab/SMT/issues/139
